### PR TITLE
fix: do not check kernel release in role

### DIFF
--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -8,5 +8,7 @@
         kernel_param_value: 3
       - kernel_param_name: net.ipv4.tcp_max_syn_backlog
         kernel_param_value: 8192
+      - kernel_param_name: fs.inotify.max_user_watches
+        kernel_param_value: 524288
   roles:
     - role: ansible-role-sysctl

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -9,6 +9,8 @@ lint: |
   ansible-lint
   flake8
 platforms:
+  - name: ubuntu1604
+    image: ubuntu:16.04
   - name: debian10
     image: debian:10
   - name: rhel8

--- a/molecule/default/tests/test_default.py
+++ b/molecule/default/tests/test_default.py
@@ -3,8 +3,8 @@ import os
 import testinfra.utils.ansible_runner
 
 testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(
-    os.environ['MOLECULE_INVENTORY_FILE']
-).get_hosts('all')
+    os.environ["MOLECULE_INVENTORY_FILE"]
+).get_hosts("all")
 
 
 def test_host(host):
@@ -13,5 +13,5 @@ def test_host(host):
 
 def test_sysctl_conf(host):
     assert host.file("/etc/sysctl.conf").contains("net.ipv4.tcp_fastopen=3")
-    assert host.file("/etc/sysctl.conf") \
-        .contains("net.ipv4.tcp_max_syn_backlog=8192")
+    assert host.file("/etc/sysctl.conf").contains("net.ipv4.tcp_max_syn_backlog=8192")
+    assert host.file("/etc/sysctl.conf").contains("fs.inotify.max_user_watches=524288")

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,15 +1,8 @@
 ---
-- name: Get Linux Kernel Version
-  set_fact:
-    linux_kernel_version: '{{ ansible_kernel.split("-")[0].split(".")[:2] | join(".") }}'
-
-# Only run this on linux with kernel versions higher than 4.11
-- name: Enable '{{ item.kernel_param_name }}'
+- name: Enable "{{ item.kernel_param_name }}"
   sysctl:
-    name: '{{ item.kernel_param_name }}'
-    value: '{{ item.kernel_param_value }}'
+    name: "{{ item.kernel_param_name }}"
+    reload: false
     state: present
-    reload: no
-  with_items: '{{ kernel_params }}'
-  when:
-    linux_kernel_version is version('4.11', '>=')
+    value: "{{ item.kernel_param_value }}"
+  with_items: "{{ kernel_params }}"


### PR DESCRIPTION
### Description

Originally, this role only applied to Linux operating systems with a
kernel release version greater than `4.11`. The kernel release version
constraint should be moved to the playbook level to allow the role to be
used by operating systems with an older kernel release version.